### PR TITLE
Use staging image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM nycplanning/library:ubuntu-latest
+FROM nycplanning/library:ubuntu-staging
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Solution we landed on is to maintain two images, a staging and a production. Production is at v1.1, and staging is at v1.2. Action v1.2 was successfully called [here](https://github.com/NYCPlanning/db-pluto/actions/runs/3069160866)