### PR TITLE
Entrypoint script should fail on python errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM nycplanning/library:ubuntu-latest
+FROM nycplanning/library:ubuntu-staging
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM nycplanning/library:ubuntu-staging
+FROM nycplanning/library:ubuntu-latest
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 if [ "$1" != "" ] ; then name="--name $1"; else name=''; fi
 if [ "$2" != "" ] ; then path="--path $2"; else path=''; fi
 if [ "$4" = "true" ] ; then s3="--s3"; else s3=''; fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 if [ "$1" != "" ] ; then name="--name $1"; else name=''; fi
 if [ "$2" != "" ] ; then path="--path $2"; else path=''; fi
@@ -10,7 +9,10 @@ if [ "$7" != "" ] ; then version="--version $7"; else version=''; fi
 
 for format in $3
 do
-  library archive $name $path -o $format $s3 $compress $latest $version &
+  if ! library archive $name $path -o $format $s3 $compress $latest $version
+  then
+    exit 1
+  fi
 done
 
 wait


### PR DESCRIPTION
Two real changes
- no longer running tasks in background. Think this is best anyways as I was getting errors of both processes trying to use/delete the same file
- explicitly exit on errors. Might have gotten away with a `set -e` in the for loop, but I figure it doesn't hurt to be explicit here